### PR TITLE
suppress warnings about missing comments on public members

### DIFF
--- a/src/NetCoreSample.Service/NetCoreSample.Service.csproj
+++ b/src/NetCoreSample.Service/NetCoreSample.Service.csproj
@@ -8,6 +8,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netcoreapp2.2\NetCoreSample.Service.xml</DocumentationFile>
+    <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
Noticed this while reading the Swashbuckle docs -- they recommend suppressing this warning if you've turned on XML documentation in order to enable controller/parameter comments to show up in the Swagger UI.